### PR TITLE
Better logger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ TARGET = $(BUILD_DIR)/udp-tunnel
 
 export
 
-default:
+$(TARGET):
 	- mkdir build
 	$(MAKE) -C src
 

--- a/src/buffer.c
+++ b/src/buffer.c
@@ -38,7 +38,7 @@ int buf_read(IPBuf *ipbuf, int fd, char *buffer, size_t nread) {
     if (!ipbuf->length || ipbuf->offset == ipbuf->length) {
         // Read from fd
         if ((actual_read = read(fd, ipbuf->buf, MAX_IP_PACKET)) < 0) {
-            log_errorf(__func__, "read from fd error: %s", strerror(errno));
+            log_errorf("read from fd error: %s", strerror(errno));
             return actual_read;
         }
         ipbuf->length = actual_read;
@@ -50,10 +50,10 @@ int buf_read(IPBuf *ipbuf, int fd, char *buffer, size_t nread) {
         discard = 1;
     }
 
-    log_debugf(__func__, "memcpy(%x, %x, %d)", buffer, ipbuf->buf + ipbuf->offset, sizeof(char) * actual_read);
+    log_debugf("memcpy(%x, %x, %d)", buffer, ipbuf->buf + ipbuf->offset, sizeof(char) * actual_read);
 
     if(memcpy(buffer, ipbuf->buf + ipbuf->offset, sizeof(char) * actual_read) == NULL) {
-        log_errorf(__func__, "memcpy error, no enough memory");
+        log_errorf("memcpy error, no enough memory");
         return -1;
     }
 

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -12,14 +12,6 @@ typedef enum LogLevel {
     FATAL = 4,
 }LogLevel;
 
-// char log_level_str[][10] = {
-//     {'D', 'E', 'B', 'U', 'G', 0},
-//     {'I', 'N', 'F', 'O', 0},
-//     {'W', 'A', 'R', 'N', 0},
-//     {'E', 'R', 'R', 'O', 'R', 0},
-//     {'F', 'A', 'T', 'A', 'L', 0}
-// };
-
 #define log_debugf(...) vlogprintf(DEBUG, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
 #define log_infof(...) vlogprintf(INFO, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
 #define log_warnf(...) vlogprintf(WARN, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
@@ -29,4 +21,4 @@ typedef enum LogLevel {
 int init_logger(char *logfile, LogLevel lv);
 void vlogprintf(LogLevel lv, const char *file_name, const char *fn_name, int line, char *fmt, ...);
 
-#endif 
+#endif

--- a/src/include/log.h
+++ b/src/include/log.h
@@ -1,6 +1,8 @@
 #ifndef _LOG_H
 #define _LOG_H
 
+#include <stdio.h>
+
 // The most verbose is shown on top -- DEBUG
 typedef enum LogLevel {
     DEBUG = 0,
@@ -18,12 +20,13 @@ typedef enum LogLevel {
 //     {'F', 'A', 'T', 'A', 'L', 0}
 // };
 
-extern char log_level_str[][30];
-void log_debugf(const char *fn_name, char *fmt, ...);
-void log_infof(const char *fn_name, char *fmt, ...);
-void log_warnf(const char *fn_name, char *fmt, ...);
-void log_errorf(const char *fn_name, char *fmt, ...);
-void log_fatalf(const char *fn_name, char *fmt, ...);
+#define log_debugf(...) vlogprintf(DEBUG, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
+#define log_infof(...) vlogprintf(INFO, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
+#define log_warnf(...) vlogprintf(WARN, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
+#define log_errorf(...) vlogprintf(ERROR, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
+#define log_fatalf(...) vlogprintf(FATAL, __FILE__, __FUNCTION__, __LINE__, __VA_ARGS__)
+
 int init_logger(char *logfile, LogLevel lv);
+void vlogprintf(LogLevel lv, const char *file_name, const char *fn_name, int line, char *fmt, ...);
 
 #endif 

--- a/src/log.c
+++ b/src/log.c
@@ -1,8 +1,8 @@
 /*************************************************************************
     > File Name: util.c
     > Author: VOID_133
-    > ################### 
-    > Mail: ################### 
+    > ###################
+    > Mail: ###################
     > Created Time: Wed 16 Aug 2017 11:19:38 AM CST
  ************************************************************************/
 #include <stdio.h>
@@ -25,7 +25,7 @@ char log_level_str[][30] = {
     "\033[1;38;5;9mFATAL"
 };
 
-FILE *LOGFILE; 
+FILE *LOGFILE;
 LogLevel LOGLV;
 
 int init_logger(char *logfile, LogLevel lv) {
@@ -41,7 +41,7 @@ int init_logger(char *logfile, LogLevel lv) {
     // Logging to file
     LOGFILE = fopen(logfile, "a");
     if(LOGFILE == NULL) {
-        return -1; 
+        return -1;
     }
     return 0;
 }
@@ -56,8 +56,8 @@ void vlogprintf(LogLevel lv, const char *fn_name, char *fmt, va_list ap) {
     if(lv < LOGLV)
         return ;
 
-    time(&rawtime); 
-    timeinfo = localtime(&rawtime); 
+    time(&rawtime);
+    timeinfo = localtime(&rawtime);
     timecut = asctime(timeinfo);
     timecut[strlen(timecut) - 1] = 0;
 
@@ -71,7 +71,7 @@ void vlogprintf(LogLevel lv, const char *fn_name, char *fmt, va_list ap) {
 // Below are logging functions
 void log_infof(const char *fn_name, char *fmt, ...) {
     va_list ap;
-    va_start(ap, fmt);     
+    va_start(ap, fmt);
     vlogprintf(INFO, fn_name, fmt, ap);
     va_end(ap);
 
@@ -80,7 +80,7 @@ void log_infof(const char *fn_name, char *fmt, ...) {
 
 void log_errorf(const char *fn_name, char *fmt, ...) {
     va_list ap;
-    va_start(ap, fmt);     
+    va_start(ap, fmt);
     vlogprintf(ERROR, fn_name, fmt, ap);
     va_end(ap);
 
@@ -89,7 +89,7 @@ void log_errorf(const char *fn_name, char *fmt, ...) {
 
 void log_warnf(const char *fn_name, char *fmt, ...) {
     va_list ap;
-    va_start(ap, fmt);     
+    va_start(ap, fmt);
     vlogprintf(WARN, fn_name, fmt, ap);
     va_end(ap);
 
@@ -98,7 +98,7 @@ void log_warnf(const char *fn_name, char *fmt, ...) {
 
 void log_debugf(const char *fn_name, char *fmt, ...) {
     va_list ap;
-    va_start(ap, fmt);     
+    va_start(ap, fmt);
     vlogprintf(DEBUG, fn_name, fmt, ap);
     va_end(ap);
 
@@ -108,7 +108,7 @@ void log_debugf(const char *fn_name, char *fmt, ...) {
 // fatal error will make the program exit right now
 void log_fatalf(const char *fn_name, char *fmt, ...) {
     va_list ap;
-    va_start(ap, fmt);     
+    va_start(ap, fmt);
     vlogprintf(FATAL, fn_name, fmt, ap);
     va_end(ap);
     exit(-1);

--- a/src/main.c
+++ b/src/main.c
@@ -10,12 +10,12 @@ int main(int argc, char **argv) {
     int tun_fd = -1;
     char tun_name[] = "udptun";
     init_logger("stderr", DEBUG);
-    log_infof(__func__, "udp-tun started, version 0.1");
+    log_infof("udp-tun started, version 0.1");
     // TODO: get options
 
     // Create kernel tunnel
     tun_fd = tun_alloc(tun_name);
-    log_infof(__func__, "tunnel create success, devname: %s", tun_name);
+    log_infof("tunnel create success, devname: %s", tun_name);
     
     // Waiting for the package to be processed
     // start the pacakge loop

--- a/src/packet.c
+++ b/src/packet.c
@@ -45,11 +45,11 @@ int read_ip_header(IPBuf *ipbuf,int fd) {
     memset(buffer, 0, sizeof(buffer));
 
     if ((nread = buf_read(ipbuf, fd, buffer, 4)) < 0) {
-        log_errorf(__func__, "read 4 bytes call error: %d %s", nread, strerror(errno));
+        log_errorf("read 4 bytes call error: %d %s", nread, strerror(errno));
         return nread;
     }
     hexstr(hexbuff, (void *)buffer, nread);
-    log_debugf(__func__, "bytes:\n%s", hexbuff);
+    log_debugf("bytes:\n%s", hexbuff);
 
     // Check if it's a UDP packet, if not, return
     if(*(int32_t *)buffer != 0x00080000) {
@@ -58,23 +58,23 @@ int read_ip_header(IPBuf *ipbuf,int fd) {
     }
 
     if ((nread = buf_read(ipbuf, fd, buffer, 1)) != 1) {
-        log_errorf(__func__, "read 1 byte call error: %d %s", nread, strerror(errno));
+        log_errorf("read 1 byte call error: %d %s", nread, strerror(errno));
         return nread;
     }
 
     ip_header_len = (buffer[0] & 0x0f) * 4;
-    log_debugf(__func__, "ip_header_len =  %d buffer[0] = %02x", ip_header_len, buffer[0]);
+    log_debugf("ip_header_len =  %d buffer[0] = %02x", ip_header_len, buffer[0]);
 
     if ((nread = buf_read(ipbuf, fd, buffer + nread, ip_header_len - 1)) != ip_header_len - 1) {
-        log_errorf(__func__, "read call error %s", strerror(errno));
+        log_errorf("read call error %s", strerror(errno));
         return nread;
     }
 
-    log_debugf(__func__, "ip packet len = %d buffer[1] = %02x", 0, ntohs(*(int16_t *)(buffer + 2)));
+    log_debugf("ip packet len = %d buffer[1] = %02x", 0, ntohs(*(int16_t *)(buffer + 2)));
     ip_packet_len = ntohs(*(int16_t *)(buffer + 2));
 
     hexstr(hexbuff, (void *)buffer, 24);
-    log_debugf(__func__, "bytes:\n%s", hexbuff);
+    log_debugf("bytes:\n%s", hexbuff);
 
     return ip_packet_len;
 }
@@ -82,7 +82,7 @@ int read_ip_header(IPBuf *ipbuf,int fd) {
 void hexstr(char *dest, void *addr, size_t size_n) {
     const uint8_t *c = addr;
     assert(addr);
-    // log_debugf(__func__, "Dumping %zu bytes from %p:", size_n, addr);
+    // log_debugf("Dumping %zu bytes from %p:", size_n, addr);
     char *p = dest;
     while (size_n > 0) {
         unsigned i;

--- a/src/test/test_buffer.c
+++ b/src/test/test_buffer.c
@@ -45,21 +45,21 @@ void test_buf_read() {
     ipbuf->length = 0;
     ipbuf->offset = 0;
     // #1 When buffer is empty, read a whole packet
-    log_infof(__func__, "#1 When buffer is empty, read a whole packet");
+    log_infof("#1 When buffer is empty, read a whole packet");
     buf_read(ipbuf, fd, resbuf, 6);
 
     if ((tmp = strcmp(resbuf, buffer)) != 0) {
-        log_errorf(__func__, "strcmp expect to return 0, %d returned\nresbuf = %s, buffer = %s", tmp, resbuf, buffer);
+        log_errorf("strcmp expect to return 0, %d returned\nresbuf = %s, buffer = %s", tmp, resbuf, buffer);
         print_process(failure);
         return ;
     }
     hexstr(hexbuff, (void *)resbuf, 6);
-    log_debugf(__func__, "bytes:\n%s", hexbuff);
+    log_debugf("bytes:\n%s", hexbuff);
 
     // #2 When buffer is not empty, read from buffer
-    log_infof(__func__, "#2 When buffer is not empty, read from buffer");
+    log_infof("#2 When buffer is not empty, read from buffer");
     if (lseek(fd, 0, SEEK_SET) < 0) {
-        log_errorf(__func__, "lseek error: %s", strerror(errno));
+        log_errorf("lseek error: %s", strerror(errno));
         print_process(error);
         return ;
     }
@@ -67,25 +67,25 @@ void test_buf_read() {
     buf_read(ipbuf, fd, resbuf, 1);
     buf_read(ipbuf, fd, resbuf, 1);
     if (resbuf[0] != buffer[1]) {
-        log_errorf(__func__, "resbuf expect to be 0x%02x, 0x%02x returned", buffer[1], resbuf[0]);
+        log_errorf("resbuf expect to be 0x%02x, 0x%02x returned", buffer[1], resbuf[0]);
         print_process(failure);
         return ;
     }
 
     // #3 When buffer is not empty, but read till end, read all
-    log_infof(__func__, "#3 When buffer is not empty but read till end, read all");
+    log_infof("#3 When buffer is not empty but read till end, read all");
     if (lseek(fd, 0, SEEK_SET) < 0) {
-        log_errorf(__func__, "lseek error: %s", strerror(errno));
+        log_errorf("lseek error: %s", strerror(errno));
         return ;
     }
     tmp = buf_read(ipbuf, fd, resbuf, 200);
     if (tmp != sizeof(buffer) - 2) {
-        log_errorf(__func__, "actual_read expceted to be %d, %d returned", sizeof(buffer) - 2, tmp);
+        log_errorf("actual_read expceted to be %d, %d returned", sizeof(buffer) - 2, tmp);
         print_process(failure);
     }
 
     hexstr(hexbuff, (void *)resbuf, 4);
-    log_debugf(__func__, "bytes:\n%s", hexbuff);
+    log_debugf("bytes:\n%s", hexbuff);
 
     close(fd);
     return ;
@@ -103,11 +103,11 @@ int mock_packet(char *file) {
     int fd = open(file, O_RDWR | O_CREAT);
     int newfd;
     if (fd < 0) {
-        log_errorf(__func__, "open tmpfile error: %s", strerror(errno));
+        log_errorf("open tmpfile error: %s", strerror(errno));
         return -1;
     }
     if (write(fd, buffer, sizeof(buffer)) !=  sizeof(buffer)) {
-        log_errorf(__func__, "write packet to tmpfile error: %s", strerror(errno));
+        log_errorf("write packet to tmpfile error: %s", strerror(errno));
         return -1;
     }
     // TODO: Maybe we do not need dup?

--- a/src/test/test_log.c
+++ b/src/test/test_log.c
@@ -10,16 +10,16 @@
 
 void test_logging() {
     init_logger("stderr", INFO);
-    log_infof(__func__, "logger print info.");
-    log_errorf(__func__, "logger print error.");
-    log_warnf(__func__, "logger print warning.");
-    log_debugf(__func__, "logger print debug.");
+    log_infof("logger print info.");
+    log_errorf("logger print error.");
+    log_warnf("logger print warning.");
+    log_debugf("logger print debug.");
 
     init_logger("/tmp/logfile", DEBUG);
-    log_infof(__func__, "logger print info.");
-    log_errorf(__func__, "logger print error.");
-    log_warnf(__func__, "logger print warning.");
-    log_debugf(__func__, "logger print debug.");
+    log_infof("logger print info.");
+    log_errorf("logger print error.");
+    log_warnf("logger print warning.");
+    log_debugf("logger print debug.");
 
     return ;
 }

--- a/src/test/test_main.c
+++ b/src/test/test_main.c
@@ -67,9 +67,9 @@ int main() {
 void run_test(void (*pf[])(), size_t size) {
     unsigned i;
     for(i = 0; i < size / sizeof(void(*)()); ++i) {
-        log_infof(__func__, "Running test #%d...\n", i);
+        log_infof("Running test #%d...\n", i);
         pf[i]();
-        log_infof(__func__, "Run test #%d done.\n", i);
+        log_infof("Run test #%d done.\n", i);
         if (test_ret_temp)
             print_process(pass);
         test_ret_temp = 1;
@@ -82,7 +82,7 @@ void assert_true(int expr) {
     if (!expr) {
         // TODO: This __func__ is meaningless.
         // We shall at least show the function name of the caller
-        log_errorf(__func__, "Assert Failure.");
+        log_errorf("Assert Failure.");
         print_process(failure);
     }
 }

--- a/src/test/test_net.c
+++ b/src/test/test_net.c
@@ -25,7 +25,7 @@ void test_tun_alloc() {
     char tun_name[] = "udptun";
     int tun;
     if ((tun = tun_alloc(tun_name)) < 0) {
-        log_errorf(__func__, "An error occurred while allocating tun.");
+        log_errorf("An error occurred while allocating tun.");
         print_process(error);
     }
     close(tun);
@@ -38,12 +38,12 @@ void test_read_ip_header() {
     ipbuf = (IPBuf *)malloc(sizeof(ipbuf));
     ipbuf->buf = (char *)malloc(sizeof(char) * MAX_BUF_LEN);
     if ((tun = tun_alloc(tun_name)) < 0) {
-        log_errorf(__func__, "An error occurred while allocating tun.");
+        log_errorf("An error occurred while allocating tun.");
         print_process(error);
         return;
     }
     if ((err = read_ip_header(NULL, tun)) < 0) {
-        log_errorf(__func__, "An error occurred while reading ip header.");
+        log_errorf("An error occurred while reading ip header.");
         print_process(error);
     }
     close(tun);

--- a/src/tun_alloc.c
+++ b/src/tun_alloc.c
@@ -29,21 +29,21 @@ int tun_alloc(char *dev) {
 
     memset(&ifr, 0, sizeof(ifr));
     if((fd = open(tun_root, O_RDWR)) < 0) {
-        log_fatalf(__func__, "fail to open clone device tun, %s", strerror(errno));
+        log_fatalf("fail to open clone device tun, %s", strerror(errno));
         // program exit
     }
-    log_debugf(__func__, "tunnel fd = %d", fd);
+    log_debugf("tunnel fd = %d", fd);
     ifr.ifr_flags = IFF_TUN;
     strncpy(ifr.ifr_name, dev, IFNAMSIZ);
 
     if((err = ioctl(fd, TUNSETIFF, (void *)&ifr)) < 0) {
         close(fd);
-        log_fatalf(__func__, "fail to create tunnel, %s", strerror(errno));
+        log_fatalf("fail to create tunnel, %s", strerror(errno));
     }
 
     if((err = ioctl(fd, TUNSETPERSIST, 1)) < 0) {
         close(fd);
-        log_fatalf(__func__, "fail to set tunnel to persist, %s", strerror(errno));
+        log_fatalf("fail to set tunnel to persist, %s", strerror(errno));
     }
 
     strcpy(dev, ifr.ifr_name);


### PR DESCRIPTION
Related: #4 

- Remove duplicated marco in log statement
- Don't output terminal color code while log file is a file
- Cancal color code at the end of line
- More debug info in log statement (filename & line number)

P.S You'd better to clean up the whitespaces in your code, use `match ErrorMsg "\s\+$"` in your `.vimrc`.
